### PR TITLE
Better parser errors

### DIFF
--- a/chem.y
+++ b/chem.y
@@ -1,3 +1,6 @@
+%define parse.trace
+%define parse.error verbose
+%define parse.lac full
 %{
 
 #include <stdio.h>


### PR DESCRIPTION
Apparently, these flags exist. So I enabled them, and now it actually prints something akin to a parse error. 