### PR TITLE
[Euler] Add support for multiple identical reactants

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ include_directories(src)
 include_directories(src/CRN)
 
 file(GLOB SOURCES "src/CRN/*.cpp")
-list(APPEND SOURCES "src/evaluator.cpp" "src/eulerevaluator.cpp" "src/networkstate.cpp")
+list(APPEND SOURCES "src/evaluator.cpp" "src/eulerevaluator.cpp" "src/networkstate.cpp" "src/reactionnetwork.cpp")
 file(GLOB TEST_SOURCES "tests/*.cpp")
 
 # add the executable

--- a/src/CRN/CRNParse.yy
+++ b/src/CRN/CRNParse.yy
@@ -25,6 +25,16 @@
 
 %code {
 # include "driver.h"
+using SpeciesPair = std::pair<std::string, int>;
+using SpeciesList = std::map<std::string, int>;
+
+void InsertToSpecieMap(SpeciesList &list, SpeciesPair &toInsert) {
+	if (list.find(toInsert.first) == list.end()) {
+		list.insert(toInsert);
+	} else {
+		list[toInsert.first] += toInsert.second;
+	}
+  }
 }
 
 %define api.token.prefix {TOK_}
@@ -79,8 +89,8 @@ reactions       : reaction { auto r = std::vector<Reaction>(); r.push_back(std::
 reaction        : species "->" species ";" { $$ = Reaction($1, $3, 1); }
                 ;
 
-species         : specie { auto map = std::map<std::string, int>(); map.insert(std::move($1)); $$ = map; }
-                | species "+" specie { auto map = std::move($1); map.insert(std::move($3)); $$ = map; }
+species         : specie { auto map = std::map<std::string, int>(); InsertToSpecieMap(map, $1); $$ = map; }
+                | species "+" specie { auto map = std::move($1); InsertToSpecieMap(map, $3); $$ = map; }
                 | "number" { if ($1 != 0) throw std::runtime_error("Parser error"); $$ = std::map<std::string, int>(); }
                 ;
 

--- a/src/eulerevaluator.cpp
+++ b/src/eulerevaluator.cpp
@@ -1,6 +1,7 @@
 #include "eulerevaluator.h"
 #include <iostream>
 #include <map>
+#include <math.h>
 #include <utility>
 
 void AddIfNotExists(map<string, int> &map, string toAdd) {
@@ -46,7 +47,7 @@ NetworkState EulerEvaluator::GetNextNetworkStateInternal() {
 		for (equation_term &term : specie.second) {
 			double change = term.first;
 			for (auto &reactant : term.second) {
-				change *= oldState[reactant.first];
+				change *= pow(oldState[reactant.first], reactant.second);
 			}
 			diff += change;
 		}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,23 +5,6 @@
 #include <iostream>
 #include <string>
 
-void PrintConcen(ReactionNetwork network) {
-	std::cout << "Printing CRN" << std::endl;
-	for (auto &conc : network.initNetworkState)
-		std::cout << "Value of " << conc.first << " is " << conc.second << '\n';
-
-	for (Reaction &r : network.reactionList) {
-		for (auto &reactant : r.reactants) {
-			std::cout << reactant.second << reactant.first << " ";
-		}
-		std::cout << "-> ";
-		for (auto &product : r.products) {
-			std::cout << product.second << product.first << " ";
-		}
-		std::cout << std::endl;
-	}
-}
-
 int main(int argc, char *argv[]) {
 	int res = 0;
 	driver drv;
@@ -45,7 +28,7 @@ int main(int argc, char *argv[]) {
 						e.GetNextNetworkState().PrintCsvRow();
 					}
 				} else {
-					PrintConcen(drv.network);
+					drv.network.Print();
 				}
 			} else {
 				std::cout << "Error while parsing" << std::endl;

--- a/src/reactionnetwork.cpp
+++ b/src/reactionnetwork.cpp
@@ -1,0 +1,34 @@
+#include "reactionnetwork.h"
+
+void ReactionNetwork::AddEmptyStates() {
+	for (auto &reaction : reactionList) {
+		for (auto &reactant : reaction.reactants) {
+			if (initNetworkState.find(reactant.first) == initNetworkState.end()) {
+				initNetworkState[reactant.first] = 0;
+			}
+		}
+
+		for (auto &product : reaction.products) {
+			if (initNetworkState.find(product.first) == initNetworkState.end()) {
+				initNetworkState[product.first] = 0;
+			}
+		}
+	}
+}
+
+void ReactionNetwork::Print() {
+	std::cout << "Printing CRN" << std::endl;
+	for (auto &conc : initNetworkState)
+		std::cout << "Value of " << conc.first << " is " << conc.second << '\n';
+
+	for (Reaction &r : reactionList) {
+		for (auto &reactant : r.reactants) {
+			std::cout << reactant.second << reactant.first << " ";
+		}
+		std::cout << "-> ";
+		for (auto &product : r.products) {
+			std::cout << product.second << product.first << " ";
+		}
+		std::cout << std::endl;
+	}
+}

--- a/src/reactionnetwork.h
+++ b/src/reactionnetwork.h
@@ -12,19 +12,6 @@ public:
 	ReactionNetwork() {}
 	NetworkState initNetworkState;
 	std::vector<Reaction> reactionList;
-	void AddEmptyStates() {
-		for (auto &reaction : reactionList) {
-			for (auto &reactant : reaction.reactants) {
-				if (initNetworkState.find(reactant.first) == initNetworkState.end()) {
-					initNetworkState[reactant.first] = 0;
-				}
-			}
-
-			for (auto &product : reaction.products) {
-				if (initNetworkState.find(product.first) == initNetworkState.end()) {
-					initNetworkState[product.first] = 0;
-				}
-			}
-		}
-	}
+	void AddEmptyStates();
+	void Print();
 };

--- a/tests/eulertest.cpp
+++ b/tests/eulertest.cpp
@@ -97,3 +97,24 @@ TEST_F(EulerTest, SanityCheck) {
 
 	EXPECT_LT(state["x"], 11);
 }
+
+TEST_F(EulerTest, MultipleSame) {
+	driver drv;
+	driver drv2;
+	// This should be the square root function. However, due to the
+	// reaction constant not being included, it's actually sqrt(x/2)
+	// instead of sqrt(x)
+	EXPECT_EQ(drv.parse_string("x:=128; x -> x + z; 2z    -> 0;"), 0);
+	EXPECT_EQ(drv2.parse_string("x:=128; x -> x + z; z + z -> 0;"), 0);
+
+	EulerEvaluator e(drv.network);
+	EulerEvaluator e2(drv2.network);
+	while (!e.IsFinished())
+		e.GetNextNetworkState();
+	while (!e2.IsFinished())
+		e2.GetNextNetworkState();
+
+	EXPECT_CLOSE(e.GetNextNetworkState()["z"], e2.GetNextNetworkState()["z"]);
+	EXPECT_CLOSE(e2.GetNextNetworkState()["z"], 8);
+	EXPECT_CLOSE(e.GetNextNetworkState()["z"], 8);
+}


### PR DESCRIPTION
First, a bugfix. When a reaction like `x + x -> z` was parsed, when the
parser would try to add the second `x` to the species list, it would
replace the first `x`, and the reaction would end up being parsed as `x
-> z`, which is very wrong. That was fixed in the parser with the
`InsertToSpecieMap` function, which handles the whole thing a lot
better.

And the main focus of this commit was adding support for reactions of
the form `2x -> y`. This was added to the euler evaluator