### PR TITLE
Remove SYNTAX.md

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -1,6 +1,0 @@
-# Syntax
- * Private and protected members are of the format `mMember`
- * Methods are PascalCase, and members and local variables are camelCase
- * Curly braces on a new line from statements
- * No spaces between funcion names and parentheses
- * Indent with tabs, align with spaces


### PR DESCRIPTION
We are not using this document anymore, because we have clang-format instead