### PR TITLE
Fix NetworkState::Diff to be absolute

### DIFF
--- a/src/evaluatorfrontend.cpp
+++ b/src/evaluatorfrontend.cpp
@@ -21,7 +21,6 @@ std::vector<std::string> EvaluatorFrontend::GeneratePlotString() {
 	if (!desiredChemicals.empty()) {
 		for (const auto &specieName : desiredChemicals) {
 			auto toPlot = initNetworkState.find(specieName);
-			std::cout << toPlot->first << std::endl;
 			if (toPlot == initNetworkState.end()) {
 				throw std::runtime_error("Tried to plot chemical not in CRN");
 			}

--- a/src/networkstate.cpp
+++ b/src/networkstate.cpp
@@ -1,4 +1,5 @@
 #include "networkstate.h"
+#include <cmath>
 
 NetworkState NetworkState::DeepCopy() {
 	NetworkState copy;
@@ -46,14 +47,14 @@ double NetworkState::Diff(const NetworkState &other) {
 	double diff = 0;
 	for (auto &pair : other) {
 		if (find(pair.first) == end()) {
-			diff += pair.second;
+			diff += std::abs(pair.second);
 		} else {
-			diff += pair.second - at(pair.first);
+			diff += std::abs(pair.second - at(pair.first));
 		}
 	}
 	for (auto &pair : *this) {
 		if (other.find(pair.first) == other.end()) {
-			diff += pair.second;
+			diff += std::abs(pair.second);
 		}
 	}
 	return diff;

--- a/tests/frontendtest.cpp
+++ b/tests/frontendtest.cpp
@@ -21,6 +21,7 @@ TEST_F(FrontendTest, PrintEvaluatedCSV) {
 	frontend.csvStream = csvStream;
 	frontend.drv = &drv;
 	EulerEvaluator e(drv.network);
+	e.threshold = 1;
 	frontend.evaluator = &e;
 	frontend.FuncRunner();
 	frontend.PrintCsvString();

--- a/tests/networkstatetest.cpp
+++ b/tests/networkstatetest.cpp
@@ -1,6 +1,6 @@
 #include "networkstate.h"
-#include "parser/driver.h"
 #include "eulerevaluator.h"
+#include "parser/driver.h"
 #include <gtest/gtest.h>
 #include <tgmath.h>
 
@@ -179,7 +179,7 @@ TEST_F(NetworkStateTest, SubtractFinding) {
 	ASSERT_EQ(std::roundf(next["b"]), 0);
 }
 
-TEST_F(NetworkStateTest, FoundABug) {
+TEST_F(NetworkStateTest, NetworkStateIsAbs) {
 	NetworkState state1;
 	state1.insert(std::pair<std::string, double>("a", 10));
 	state1.insert(std::pair<std::string, double>("b", 0));
@@ -189,6 +189,4 @@ TEST_F(NetworkStateTest, FoundABug) {
 	state2["b"] = 0.1;
 
 	ASSERT_FLOAT_EQ(state1.Diff(state2), 0.2);
-
-
 }

--- a/tests/networkstatetest.cpp
+++ b/tests/networkstatetest.cpp
@@ -178,3 +178,17 @@ TEST_F(NetworkStateTest, SubtractFinding) {
 	ASSERT_EQ(next["a"], 0);
 	ASSERT_EQ(std::roundf(next["b"]), 0);
 }
+
+TEST_F(NetworkStateTest, FoundABug) {
+	NetworkState state1;
+	state1.insert(std::pair<std::string, double>("a", 10));
+	state1.insert(std::pair<std::string, double>("b", 0));
+
+	NetworkState state2 = state1.DeepCopy();
+	state2["a"] = 9.9;
+	state2["b"] = 0.1;
+
+	ASSERT_FLOAT_EQ(state1.Diff(state2), 0.2);
+
+
+}


### PR DESCRIPTION
Previously, NetworkState::Diff would not take absolute values when calculating differences. This would result in the two states <1,0> and <0,1> being considered effectively the same, prematurely ending the
simulation.