### PR TITLE
Added make install  to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,3 +49,5 @@ add_executable(tests
 	${FLEX_scanner_OUTPUTS}
 )
 target_link_libraries(tests ${GTEST_BOTH_LIBRARIES} Boost::iostreams Boost::system)
+
+install(TARGETS crnsimul DESTINATION /usr/bin/)


### PR DESCRIPTION
This place the crnsimul in the /usr/bin/ directory.
The command has to be run as sudo.
"sudo make install". It is now possible to run Chemilang output files
directly to crnsimul. 

THIS IS ONLY TESTED ON ARCH LINUX!!