### PR TITLE
Made evaluators throw error on NaN concentrations

### DIFF
--- a/src/eulerevaluator.cpp
+++ b/src/eulerevaluator.cpp
@@ -56,6 +56,7 @@ NetworkState EulerEvaluator::GetNextNetworkState() {
 	}
 	mState.time = step * iterations;
 	finished = (oldState.Diff(mState) < threshold);
+	mState.Verify();
 	return mState;
 }
 // [flag]

--- a/src/markovevaluator.cpp
+++ b/src/markovevaluator.cpp
@@ -61,6 +61,7 @@ NetworkState MarkovEvaluator::GetNextNetworkState() {
 	mState = mState - reaction.reactants;
 	mState = mState + reaction.products;
 	mState.time = currentTime;
+	mState.Verify();
 	return mState;
 }
 // [region]

--- a/src/networkstate.cpp
+++ b/src/networkstate.cpp
@@ -101,3 +101,11 @@ NetworkState NetworkState::operator-(const NetworkState &other) {
 	}
 	return state;
 }
+
+void NetworkState::Verify() {
+	for (const auto &specie : *this) {
+		// A number that is NaN will not be equal to itself
+		if (specie.second != specie.second)
+			throw DoubleOverflowException();
+	}
+}

--- a/src/networkstate.h
+++ b/src/networkstate.h
@@ -12,6 +12,13 @@ class NetworkStateOutOfRange : public std::exception {
 	}
 };
 
+struct DoubleOverflowException : public std::exception {
+	const char *what() const throw() {
+		return "One of the specie concentrations reached an invalid value. Try "
+					 "decreasing the step size.";
+	}
+};
+
 //! Class to represent a networkstate.
 /*! The networkstate represents the current state of the network.
 This is represented through a map. This map contains a string, namely
@@ -25,6 +32,7 @@ public:
 	void Print();
 	double time = 0;
 	double Diff(const NetworkState &other);
+	void Verify();
 	NetworkState operator+(const NetworkState &);
 	NetworkState operator-(const NetworkState &);
 };

--- a/tests/eulertest.cpp
+++ b/tests/eulertest.cpp
@@ -1,6 +1,8 @@
 #include "eulerevaluator.h"
 #include "parser/driver.h"
 #include <gtest/gtest.h>
+#include <limits>
+#include <math.h>
 
 #define EXPECT_CLOSE(a, b) EXPECT_LT(abs((b) - (a)), 1)
 
@@ -333,4 +335,14 @@ TEST_F(EulerTest, MultipleSame) {
 	EXPECT_EQ(e.GetNextNetworkState()["z"], e2.GetNextNetworkState()["z"]);
 	EXPECT_CLOSE(e2.GetNextNetworkState()["z"], 12);
 	EXPECT_CLOSE(e.GetNextNetworkState()["z"], 12);
+}
+
+TEST_F(EulerTest, OverflowException) {
+	driver drv;
+	ASSERT_EQ(drv.parse_string("a := 1000000000; a ->(100) b;"), 0);
+	drv.network.initNetworkState["b"] = std::numeric_limits<double>::max();
+	EulerEvaluator e(drv.network);
+	e.step = INFINITY;
+	e.GetNextNetworkState();
+	EXPECT_THROW(e.GetNextNetworkState(), DoubleOverflowException);
 }


### PR DESCRIPTION
When testing out different CRN's I accidentally caused an double overflow. However, I had no way of finding it out, because the evaluators didn't care. Now they throw an exception if it happens during the simulation, and suggests that the user decreases the step size.