### PR TITLE
Add OpenRTPlotter dependencies to Nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,15 @@
 with import <nixpkgs> {};
 
+let
+  unstable = import
+    (fetchTarball
+      https://github.com/NixOS/nixpkgs-channels/archive/nixos-unstable.tar.gz) {};
+in
 stdenv.mkDerivation {
   name = "crnsimul";
   src = ./.;
 
-  buildInputs = [ cmake clang boost flex bison gnuplot gtest ];
+  buildInputs = [ cmake clang boost flex bison gnuplot gtest glew unstable.glfw freetype glm fontconfig ];
 
   buildPhase = "cmake . && make && ./bin/tests";
 


### PR DESCRIPTION
This might not be the cleanest way to do it, but I couldn't/didn't want to spend time figuring out how to inherit from the submodules.

And I think it's a good thing to have the build script work. 